### PR TITLE
Fixed some typos

### DIFF
--- a/r-database-docker/03-learning-goals-use-cases.Rmd
+++ b/r-database-docker/03-learning-goals-use-cases.Rmd
@@ -15,7 +15,7 @@ After working through this tutorial, you can expect to be able to:
 * Understand some of the trade-offs between:
     1. queries aimed at exploration or informal investigation using [dplyr](https://cran.r-project.org/package=dplyr); and 
     2. those where performance is important because of the size of the database or the frequency with which a query is run.
-* Rewrite dplyr queries as SQL and submit them directly. 
+* Rewrite `dplyr` queries as SQL and submit them directly. 
 * Gain some understanding of techniques for assessing query structure and performance.
 * Set up a PostgreSQL database in a Docker environment.
 * Understand enough about Docker to swap databases, e.g. [Sports DB](http://www.sportsdb.org/sd/samples) for the [DVD rental database](http://www.postgresqltutorial.com/postgresql-sample-database/) used in this tutorial. Or swap the database management system (DBMS), e.g. [MySQL](https://www.mysql.com/) for [PostgreSQL](https://www.postgresql.org/).

--- a/r-database-docker/10-r-postgres-interaction.Rmd
+++ b/r-database-docker/10-r-postgres-interaction.Rmd
@@ -24,15 +24,15 @@ read_chunk('book-src/db-login-batch-code.R')
 
 ## Basics
 
-* keeping passwords secure
+* Keeping passwords secure.
 * Coverage in this book.  There are many SQL tutorials that are available.  For example, we are drawing some materials from  [a tutorial we recommend](http://www.postgresqltutorial.com/postgresql-sample-database/).  In particular, we will not replicate the lessons there, which you might want to complete.  Instead, we are showing strategies that are recommended for R users.  That will include some translations of queries that are discussed there.
 
-## Ask yourself about what you are aiming for?
+## Ask yourself, what are you aiming for?
 
-* differences between production and data warehouse environments
-* learning to keep your DBAs happy
+* Differences between production and data warehouse environments.
+* Learning to keep your DBAs happy:
   + You are your own DBA in this simulation, so you can wreak havoc and learn from it, but you can learn to be DBA-friendly here.
-  + in the end it's the subject-matter experts that understand your data, but you have to work with your DBAs first
+  + In the end it's the subject-matter experts that understand your data, but you have to work with your DBAs first.
 
 ## Get some basic information about your database
 

--- a/r-database-docker/11-elementary-queries.Rmd
+++ b/r-database-docker/11-elementary-queries.Rmd
@@ -74,7 +74,7 @@ discuss this simple example? http://www.postgresqltutorial.com/postgresql-left-j
 * Glue for constructing SQL statements
   + parameterizing SQL queries
 
-## Chosing between dplyr and native SQL
+## Choosing between dplyr and native SQL
 
 * performance considerations: first get the right data, then worry about performance
 * Trade offs between leaving the data in PostgreSQL vs what's kept in R: 

--- a/r-database-docker/11-elementary-queries.Rmd
+++ b/r-database-docker/11-elementary-queries.Rmd
@@ -33,18 +33,18 @@ library(skimr)
 * find out how the data is used by those who enter it and others who've used it before
   + why is there missing data?
 
-## Using Dplyr
+## Using `dplyr`
 
 We already started, but that's OK.
 
-### finding out what's in the database
+### Finding out what's in the database
 
 * DBI / RPostgres packages
 * R tools like glimpse, skimr, kable.
 * Tutorials like: https://suzan.rbind.io/tags/dplyr/ 
 * Benjamin S. Baumer, A Grammar for Reproducible and Painless Extract-Transform-Load Operations on Medium Data: https://arxiv.org/pdf/1708.07073 
 
-### sample query
+### Sample query
 
 * rental 
 * date subset
@@ -61,10 +61,10 @@ We already started, but that's OK.
 
 discuss this simple example? http://www.postgresqltutorial.com/postgresql-left-join/ 
 
-* dplyr joins on the server side
+* `dplyr` joins on the server side
 * Where you put `(collect(n = Inf))` really matters
 
-## What is dplyr sending to the server?
+## What is `dplyr` sending to the server?
 
 * show_query as a first draft
 
@@ -74,7 +74,7 @@ discuss this simple example? http://www.postgresqltutorial.com/postgresql-left-j
 * Glue for constructing SQL statements
   + parameterizing SQL queries
 
-## Choosing between dplyr and native SQL
+## Choosing between `dplyr` and native SQL
 
 * performance considerations: first get the right data, then worry about performance
 * Trade offs between leaving the data in PostgreSQL vs what's kept in R: 

--- a/r-database-docker/12-a-production-perspective.Rmd
+++ b/r-database-docker/12-a-production-perspective.Rmd
@@ -1,6 +1,6 @@
 # Leftovers (12)
 
-Most of the content in this file has een moved elsewhere.
+Most of the content in this file has been moved elsewhere.
 
 ```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
 knitr::opts_chunk$set(echo = TRUE)

--- a/r-database-docker/21-r-query-postgres-metadata.Rmd
+++ b/r-database-docker/21-r-query-postgres-metadata.Rmd
@@ -32,7 +32,7 @@ con <- wait_for_postgres(user = Sys.getenv("DEFAULT_POSTGRES_USER_NAME"),
                          dbname = "dvdrental",
                          seconds_to_test = 10)
 ```
-So far in this books we've most often looked at the data by listing a few observations or using a tool like `glimpse`.
+So far in this book, we've most often looked at the data by listing a few observations or using a tool like `glimpse`.
 ```{r}
 rental <- tbl(con, "rental")
 
@@ -40,7 +40,7 @@ kable(head(rental))
 glimpse(rental)
 ```
 
-For large or complex databases, however, you need to use both the available documentation for your database (e.g.,  [the dvdrental](http://www.postgresqltutorial.com/postgresql-sample-database/) dataase) and the other empirical tools that are available.  For example it's worth learning to interpret the symbols in an [Entity Relationship Diagram](https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model):
+For large or complex databases, however, you need to use both the available documentation for your database (e.g.,  [the dvdrental](http://www.postgresqltutorial.com/postgresql-sample-database/) database) and the other empirical tools that are available.  For example it's worth learning to interpret the symbols in an [Entity Relationship Diagram](https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model):
 
 ![](./screenshots/ER-diagram-symbols.png)
 
@@ -74,7 +74,7 @@ public_table_columns
 
 Pull out some rough-and-ready but useful statistics about your database.  Since we are in SQL-land we talk about variables as `columns`.
 
-Start with a list of tables names and a count of the number of columns that each one contains.
+Start with a list of table names and a count of the number of columns that each one contains.
 ```{r}
 
 public_table_columns %>% 

--- a/r-database-docker/71-explain-queries.Rmd
+++ b/r-database-docker/71-explain-queries.Rmd
@@ -9,7 +9,7 @@ library(glue)
 library(knitr)
 ```
 
-* examining dplyr queries (show_query on the R side v EXPLAIN on the PostgreSQL side)
+* examining `dplyr` queries (`dplyr::show_query` on the R side v EXPLAIN on the PostgreSQL side)
 
 ```{r echo=FALSE}
 read_chunk('book-src/db-login-batch-code.R')
@@ -38,13 +38,13 @@ con <- wait_for_postgres(user = Sys.getenv("DEFAULT_POSTGRES_USER_NAME"),
                          seconds_to_test = 10)
 ```
 
-## Performance considertations
+## Performance considerations
 
 ```{r}
-## Explain a dplyr join
+## Explain a `dplyr::join`
 
 ## Explain the quivalent SQL join
-rs1 <- dbGetQuery(con
+rs1 <- DBI::dbGetQuery(con
                  ,"SELECT c.* 
                      FROM pg_catalog.pg_class c
                      JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
@@ -59,14 +59,14 @@ head(rs1)
 
 This came from 14-sql_pet-examples-part-b.Rmd
 ```{r}
-rs1 <- dbGetQuery(con,
+rs1 <- DBI::dbGetQuery(con,
                 "explain select r.*
                    from rental r 
                  ;"
                 )  
 head(rs1)
 
-rs2 <- dbGetQuery(con,
+rs2 <- DBI::dbGetQuery(con,
                 "explain select count(*) count
                    from rental r 
                         left outer join payment p 
@@ -75,7 +75,7 @@ rs2 <- dbGetQuery(con,
                  ;")
 head(rs2)
 
-rs3 <- dbGetQuery(con,
+rs3 <- DBI::dbGetQuery(con,
                 "explain select sum(f.rental_rate) open_amt,count(*) count
                    from rental r 
                         left outer join payment p 
@@ -88,7 +88,7 @@ rs3 <- dbGetQuery(con,
                  ;")
 head(rs3)
 
-rs4 <- dbGetQuery(con,
+rs4 <- DBI::dbGetQuery(con,
                 "explain select c.customer_id,c.first_name,c.last_name,sum(f.rental_rate) open_amt,count(*) count
                    from rental r 
                         left outer join payment p 

--- a/r-database-docker/89-resources.Rmd
+++ b/r-database-docker/89-resources.Rmd
@@ -14,7 +14,7 @@
 * Scott Came's materials about Docker and R [on his website](http://www.cascadia-analytics.com/2018/07/21/docker-r-p1.html) and at the 2018 UseR Conference focus on **R inside Docker**.
 * It's worth studying the [ROpensci Docker tutorial](https://ropenscilabs.github.io/r-docker-tutorial/)
 
-## Documentation Docker and Postgres
+## Documentation for Docker and Postgres
 
 * [The Postgres image documentation](https://docs.docker.com/samples/library/postgres/)
 * [Dockerize PostgreSQL](https://docs.docker.com/engine/examples/postgresql_service/)

--- a/r-database-docker/92-environment_diagram.Rmd
+++ b/r-database-docker/92-environment_diagram.Rmd
@@ -82,7 +82,7 @@ postgres_ver <- dbGetQuery(con,"select version()") %>%
 
 ```
 
-The following code block uses the data generated from the previous code block as input to the subgraphs, the ones outlined in red.  The application nodes are the parents of the subgraphs and are not outlined in reds.  The `Environment` application node represents the machine you are running the tutorial on and hosts the sub-applications.  
+The following code block uses the data generated from the previous code block as input to the subgraphs, the ones outlined in red.  The application nodes are the parents of the subgraphs and are not outlined in red.  The `Environment` application node represents the machine you are running the tutorial on and hosts the sub-applications.  
 
 Note that the '@@' variables are populated at the end of the `Environment` definition following the `## @@1 - @@5` source data comment.
 
@@ -172,7 +172,7 @@ digraph Envgraph {
 ")
 ```
 
-One sub-application not shown above is your local console/terminal/cli application.  In the tutorial, fully constructed docker commands are printed out and then executed.  If for some reason the executed docker command fails, one can copy and paste it into your local terminal window to see additional error information.  Failures seem more prevalent in the Windows environment.
+One sub-application not shown above is your local console/terminal/CLI application.  In the tutorial, fully constructed docker commands are printed out and then executed.  If for some reason the executed docker command fails, one can copy and paste it into your local terminal window to see additional error information.  Failures seem more prevalent in the Windows environment.
 
 ## Communicating with Docker Applications
 


### PR DESCRIPTION
* Minor edits to improve consistency and readability.
* Fixed some typos.
* Made some minor format changes:
    * Using back-quote around package or function names. For example:
        * dplyr => `dplyr`
    I did not do this consistently across all function names. I thought I would wait to see if team members agree with this formatting style.
    * Fully qualified some function names by using their package name as a prefix. See Issue #93 regarding this format.

*Note*: This pull request only contains the changes to the source files. I did not regenerate the `/docs` files.