### PR TITLE
stop making the PDF

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -9,7 +9,5 @@ output_dir: "docs"
 new_session: yes
 site: "bookdown::bookdown_site"
 output:
-  bookdown::pdf_book:
-    keep_tex: yes
   bookdown::gitbook:
     lib_dir: "book_assets"

--- a/_output.yml
+++ b/_output.yml
@@ -6,11 +6,4 @@ bookdown::gitbook:
         <li><a href="./">R, Databases and Docker</a></li>
       after: |
         <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
-    download: ["pdf"]
     edit: https://github.com/smithjd/sql-pet/edit/master/%s
-bookdown::pdf_book:
-  includes:
-    in_header: preamble.tex
-  latex_engine: xelatex
-  citation_package: natbib
-  keep_tex: yes

--- a/build_book.R
+++ b/build_book.R
@@ -8,14 +8,6 @@
 # clear the directory
 bookdown::clean_book(TRUE)
 
-# PDF
-bookdown::render_book(
-  input = "index.Rmd",
-  new_session = TRUE,
-  output_format = "bookdown::pdf_book",
-  output_dir = "docs"
-)
-
 # "GitBook" website
 
 bookdown::render_book(


### PR DESCRIPTION
It's slowing us down now - we can always put it back before the workshop, although by then we'll probably have a workshop handout instead.