### PR TITLE
Fixed SQL statement to return random rows.

### DIFF
--- a/080-elementary-queries.Rmd
+++ b/080-elementary-queries.Rmd
@@ -111,7 +111,7 @@ When the dbms contains many rows, a sample of the data may be plenty for your pu
 ```{r}
 one_percent_sample <- DBI::dbGetQuery(
   con,
-  "SELECT rental_id, rental_date, inventory_id, customer_id FROM rental TABLESAMPLE SYSTEM(1) LIMIT 20;
+  "SELECT rental_id, rental_date, inventory_id, customer_id FROM rental TABLESAMPLE BERNOULLI(1) LIMIT 20;
   "
 )
 


### PR DESCRIPTION
In Section 9.1.6 "Random rows from the dbms", the supposedly "random" rows have consecutive `rental_id` values. That looks suspiciously non-random to me. Per [PostgreSQL documentation](https://wiki.postgresql.org/wiki/TABLESAMPLE_Implementation#About_TABLESAMPLE_Clause), the `<sample method>` should be `BERNOULLI`, not `SYSTEM`.

I made that fix and confirmed that random rows are returned now.