### PR TITLE
Fixed sample code in Ch. 10

### DIFF
--- a/090-lazy-evalutation-and-downloading.Rmd
+++ b/090-lazy-evalutation-and-downloading.Rmd
@@ -197,12 +197,12 @@ Q %>% head()
 ### Q %>% tail() {#lazy_q_tail}
 
 ![](screenshots/red-x.png) Produces an error, because `Q` does not hold all of the data, so it is not possible to list the last few items from the table:
-```r
-Q %>% tail()  # Causes an error!
-```
-
-```
-Error: tail() is not supported by sql sources
+```{r}
+try(
+  Q %>% tail(),
+  silent = FALSE,
+  outFile = stdout()
+)
 ```
 
 ### Q %>% length() {#lazy_q_length}

--- a/090-lazy-evalutation-and-downloading.Rmd
+++ b/090-lazy-evalutation-and-downloading.Rmd
@@ -197,8 +197,12 @@ Q %>% head()
 ### Q %>% tail() {#lazy_q_tail}
 
 ![](screenshots/red-x.png) Produces an error, because `Q` does not hold all of the data, so it is not possible to list the last few items from the table:
-```{r}
-Q %>% tail()
+```r
+Q %>% tail()  # Causes an error!
+```
+
+```
+Error: tail() is not supported by sql sources
 ```
 
 ### Q %>% length() {#lazy_q_length}


### PR DESCRIPTION
Fixed sample code that produces an error, which causes bookdown to fail. The code is *supposed* to throw an exception, so the code needs to be wrapped in a `try` call, in order to produce the correct output when the book is built.